### PR TITLE
Adiciona Terraform pra criar a máquina na AWS mais facilmente

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 **/.env
 **/data
 domjudge/logs
+**/.terraform*
+**/terraform.tfstate*

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -1,0 +1,17 @@
+resource "aws_instance" "domjudge_machine" {
+  ami           = "ami-0b5eea76982371e91"
+  instance_type = "t2.micro"
+  
+  security_groups = [ "default", "allow-ssh" ]
+
+  user_data = file("./userdata.yaml")
+	iam_instance_profile = aws_iam_instance_profile.iam_profile.name 
+
+  tags = {
+    Name = "DomJudge"
+  }
+}
+
+output "instance_id" {
+  value = aws_instance.domjudge_machine.id
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,14 @@
+resource "aws_iam_instance_profile" "iam_profile" {
+  name = "domjudge_profile"
+  role = aws_iam_role.ec2_role.name
+}
+
+resource "aws_iam_role" "ec2_role" {
+  name = "domjudge_ec2_role"
+  assume_role_policy = file("iam/iam-trust-relationships.json")
+}
+
+resource "aws_iam_role_policy" "policy" {
+  role = aws_iam_role.ec2_role.id
+  policy = file("iam/allow-connect.json")
+}

--- a/terraform/iam/allow-connect.json
+++ b/terraform/iam/allow-connect.json
@@ -1,0 +1,22 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": "ec2-instance-connect:SendSSHPublicKey",
+        "Resource": [
+            "arn:aws:ec2:us-east-1:042898590549:instance/i-0c624b355de723ede"
+        ],
+        "Condition": {
+            "StringEquals": {
+                "ec2:osuser": "ec2-user"
+            }
+        }
+      },
+      {
+        "Effect": "Allow",
+        "Action": "ec2:DescribeInstances",
+        "Resource": "*"
+      }
+    ]
+}

--- a/terraform/iam/iam-trust-relationships.json
+++ b/terraform/iam/iam-trust-relationships.json
@@ -1,0 +1,14 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "TrustRelationships",
+            "Action": "sts:AssumeRole",
+            "Principal": {
+                "Service": "ec2.amazonaws.com"
+            },
+            "Effect": "Allow"
+        }
+    ]
+}
+

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
+# Configure the AWS Provider
+provider "aws" {
+  region = "us-east-1"
+}

--- a/terraform/userdata.yaml
+++ b/terraform/userdata.yaml
@@ -1,0 +1,45 @@
+#cloud-config
+
+repo_update: false
+repo_upgrade: all
+
+package_upgrade: true
+
+packages:
+  - docker
+
+runcmd:
+  - [ sh, -c, "amazon-linux-extras install -y docker" ]
+
+write_files:
+  - path: /etc/docker/daemon.json
+    owner: root:root
+    permissions: 0644
+    content: |
+      {
+        "log-driver": "none"
+      }
+  - path: /etc/sysconfig/docker
+    owner: root:root
+    permissions: 0644
+    content: |
+      DAEMON_MAXFILES=1048576
+      OPTIONS="--default-ulimit nofile=1024000:1024000"
+      DAEMON_PIDFILE_TIMEOUT=10
+    
+  - path: /etc/systemd/journald.conf
+    append: true
+    content: |
+      [Journal]
+      SystemMaxUse=500M
+      SystemMaxFileSize=100M 
+
+runcmd:
+  - usermod -a -G docker ec2-user
+  - systemctl daemon-reload
+  - systemctl enable docker
+  - systemctl start docker
+  - yum install -y jq.x86_64 git.x86_64
+  - amazon-linux-extras install epel -y
+  - curl -L https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
+  - chmod +x /usr/local/bin/docker-compose


### PR DESCRIPTION
O Terraform facilita a criação da máquina na AWS. A máquina que é criada com o código desse PR já deixa o docker + compose pré-configurado, e dá pra acessar via ssh, [mssh](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-connect-set-up.html#ec2-instance-connect-install-eic-CLI) ou direto no console da AWS (clicando em 'Connect')